### PR TITLE
yaml.load() to yaml.safe_load()

### DIFF
--- a/searchtweets/credentials.py
+++ b/searchtweets/credentials.py
@@ -31,7 +31,7 @@ def _load_yaml_credentials(filename=None, yaml_key=None):
     """
     try:
         with open(os.path.expanduser(filename)) as f:
-            search_creds = yaml.load(f)[yaml_key]
+            search_creds = yaml.safe_load(f)[yaml_key]
     except FileNotFoundError:
         logger.error("cannot read file {}".format(filename))
         search_creds = {}


### PR DESCRIPTION
Details: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
PyYAML's load function has been unsafe since the first release in May 2006. It has always been documented that way in bold type: PyYAMLDocumentation. PyYAML has always provided a safe_load function that can load a subset of YAML without exploit.